### PR TITLE
feat: add `EmbodimentInfo` service

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,12 +14,12 @@ find_package(ament_cmake REQUIRED)
 find_package(std_msgs REQUIRED)
 find_package(vision_msgs REQUIRED)
 find_package(sensor_msgs REQUIRED)
-find_package(action_msgs REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
 
 rosidl_generate_interfaces(${PROJECT_NAME}
   "srv/ManipulatorMoveTo.srv"
   "srv/VectorStoreRetrieval.srv"
+  "srv/EmbodimentInfo.srv"
   "srv/StringList.srv"
   "msg/RAIDetectionArray.msg"
   "msg/AudioMessage.msg"
@@ -29,7 +29,7 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "action/Task.action"
   "action/TaskFeedback.action"
   "srv/WhatISee.srv"
-  DEPENDENCIES std_msgs vision_msgs sensor_msgs geometry_msgs action_msgs
+  DEPENDENCIES std_msgs vision_msgs sensor_msgs geometry_msgs
 )
 
 if(BUILD_TESTING)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ find_package(ament_cmake REQUIRED)
 find_package(std_msgs REQUIRED)
 find_package(vision_msgs REQUIRED)
 find_package(sensor_msgs REQUIRED)
+find_package(action_msgs REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
 
 rosidl_generate_interfaces(${PROJECT_NAME}
@@ -29,7 +30,7 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "action/Task.action"
   "action/TaskFeedback.action"
   "srv/WhatISee.srv"
-  DEPENDENCIES std_msgs vision_msgs sensor_msgs geometry_msgs
+  DEPENDENCIES std_msgs vision_msgs sensor_msgs geometry_msgs action_msgs
 )
 
 if(BUILD_TESTING)

--- a/package.xml
+++ b/package.xml
@@ -2,19 +2,16 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>rai_interfaces</name>
-  <version>0.2.2</version>
+  <version>0.2.0</version>
   <description>Interfaces for RAI communication</description>
     <maintainer email="adam.dabrowski@robotec.ai">Adam Dabrowski</maintainer>
     <maintainer email="kajetan.rachwal@robotec.ai">Kajetan Rachwał</maintainer>
-    <maintainer email="maciej.majek@robotec.ai">Maciej Majek</maintainer>
-    <maintainer email="kacper.dabrowski@robotec.ai">Kacper Dąbrowski</maintainer>
   <license>Apache-2.0</license>
 
   <depend>std_msgs</depend>
   <depend>geometry_msgs</depend>
   <depend>vision_msgs</depend>
   <depend>sensor_msgs</depend>
-  <depend>action_msgs</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/package.xml
+++ b/package.xml
@@ -2,16 +2,19 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>rai_interfaces</name>
-  <version>0.2.0</version>
+  <version>0.2.3</version>
   <description>Interfaces for RAI communication</description>
     <maintainer email="adam.dabrowski@robotec.ai">Adam Dabrowski</maintainer>
     <maintainer email="kajetan.rachwal@robotec.ai">Kajetan Rachwał</maintainer>
+    <maintainer email="maciej.majek@robotec.ai">Maciej Majek</maintainer>
+    <maintainer email="kacper.dabrowski@robotec.ai">Kacper Dąbrowski</maintainer>
   <license>Apache-2.0</license>
 
   <depend>std_msgs</depend>
   <depend>geometry_msgs</depend>
   <depend>vision_msgs</depend>
   <depend>sensor_msgs</depend>
+  <depend>action_msgs</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/package.xml
+++ b/package.xml
@@ -2,19 +2,16 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>rai_interfaces</name>
-  <version>0.2.3</version>
+  <version>0.2.1</version>
   <description>Interfaces for RAI communication</description>
     <maintainer email="adam.dabrowski@robotec.ai">Adam Dabrowski</maintainer>
     <maintainer email="kajetan.rachwal@robotec.ai">Kajetan Rachwał</maintainer>
-    <maintainer email="maciej.majek@robotec.ai">Maciej Majek</maintainer>
-    <maintainer email="kacper.dabrowski@robotec.ai">Kacper Dąbrowski</maintainer>
   <license>Apache-2.0</license>
 
   <depend>std_msgs</depend>
   <depend>geometry_msgs</depend>
   <depend>vision_msgs</depend>
   <depend>sensor_msgs</depend>
-  <depend>action_msgs</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/srv/EmbodimentInfo.srv
+++ b/srv/EmbodimentInfo.srv
@@ -1,0 +1,23 @@
+#
+# Copyright (C) 2024 Robotec.AI
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#          http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+# Request
+---
+# Response
+string[] rules
+string[] capabilities
+string[] behaviors
+string description
+string[] images # base64 encoded png images


### PR DESCRIPTION
Migrates the service from the `rai` repo that was added in this PR: https://github.com/RobotecAI/rai/pull/540
